### PR TITLE
Fix animations config parser dropping vars and list-form entity

### DIFF
--- a/src/App/Extensions/Animation/Config.cpp
+++ b/src/App/Extensions/Animation/Config.cpp
@@ -47,7 +47,7 @@ void App::AnimationsConfig::LoadYAML(const YAML::Node& aNode)
         {
             entry.entities.insert(entityNode.Scalar());
         }
-        else if (entityNode.IsScalar())
+        else if (entityNode.IsSequence())
         {
             for (const auto& pathNode : entityNode)
             {
@@ -79,7 +79,7 @@ void App::AnimationsConfig::LoadYAML(const YAML::Node& aNode)
         {
             for (const auto& variableNode : variablesNode)
             {
-                if (variablesNode.IsScalar())
+                if (variableNode.IsScalar())
                 {
                     entry.variables.push_back(variableNode.Scalar());
                 }


### PR DESCRIPTION
Two potential typos in AnimationsConfig::LoadYAML:

- The `vars` loop tested the sequence node (`variablesNode.IsScalar()`) instead of the item, so the condition was always false and `entry.variables` stayed empty. Entries declared with `vars:` were injected with empty `variableNames`, i.e. the anim set mounted unconditionally instead of being variable-gated.

- The list form of `entity` repeated the scalar check instead of testing `IsSequence()`, so a sequence of entity paths never parsed and the entry was rejected as malformed.