### PR TITLE
Don't mutate the appearances map under a shared lock

### DIFF
--- a/src/App/Extensions/ResourcePatch/Extension.cpp
+++ b/src/App/Extensions/ResourcePatch/Extension.cpp
@@ -1497,5 +1497,9 @@ Red::Handle<Red::AppearanceDefinition> App::ResourcePatchExtension::PatchInstanc
     if (appearanceIt != appearances.end())
         return appearanceIt.value();
 
-    return appearances[{}];
+    auto defaultIt = appearances.find({});
+    if (defaultIt != appearances.end())
+        return defaultIt.value();
+
+    return {};
 }


### PR DESCRIPTION
Fixes #20.

`GetAppearanceDefinition` holds a `shared_lock`, but its fallback calls `operator[]`, which inserts the `{}` key when it is absent. That insert can rehash — allocate a new bucket array, copy the entries over, and free the old one — while other threads are concurrently walking the same map under the same shared lock.

It is reached from `PatchPackageResults` on the `OnEntityPackageLoad` streaming jobs, which run concurrently for many entities, so concurrent callers are the normal case rather than an edge case.

Observed with symbols as a **wild** pointer read (`0x34890050000`, not null) at `hopscotch_hash.h:1321` — inside `rehash_impl`'s bucket-copy loop, `for (auto it_bucket = m_buckets_data.begin(); ...)`. The crashing thread was walking a bucket array that a concurrent mutation had reallocated out from under it:

```
ArchiveXL.dll!tsl::detail_hopscotch_hash::hopscotch_hash<...AppearanceDefinition...>  (hopscotch_hash.h:1321)
ArchiveXL.dll!App::ResourcePatchExtension::PatchInstance::GetAppearanceDefinition +0x1C3  (Extension.cpp:1573)
ArchiveXL.dll!App::ResourcePatchExtension::PatchPackageResults +0xC4  (Extension.cpp:1167)
ArchiveXL.dll!RED4ext::JobClosure<...OnEntityPackageLoad'::`2'::<lambda_2>>::HandleTarget  (JobQueue.hpp:196)
```

The fallback only needs to *read* the default entry, so a plain `find` keeps the whole function read-only and safe under the shared lock. Behaviour is unchanged when the `{}` key exists; when it does not, the function now returns a null handle instead of inserting one — which is what callers already treat as "no patch definition" (`if (!patchDefinition) continue;`).

Tested on a large load order (~1500 archives) that reproduced the crash within 30–105 s of a save load. With this change the same setup ran through repeated streaming-heavy loads and a 66-minute session with no fault in ArchiveXL.
